### PR TITLE
Jst/fixes for linux paths

### DIFF
--- a/DMApp.Common/AppPackageCreator.cs
+++ b/DMApp.Common/AppPackageCreator.cs
@@ -1,7 +1,6 @@
 namespace Skyline.DataMiner.CICD.DMApp.Common
 {
     using System;
-    using System.IO;
     using System.Threading.Tasks;
 
     using Skyline.AppInstaller;
@@ -59,7 +58,7 @@ namespace Skyline.DataMiner.CICD.DMApp.Common
 
             if (!fileSystem.Directory.Exists(repositoryPath))
             {
-                throw new DirectoryNotFoundException("The specified directory '" + repositoryPath + "' does not exist.");
+                throw new System.IO.DirectoryNotFoundException("The specified directory '" + repositoryPath + "' does not exist.");
             }
 
             RepositoryPath = fileSystem.Path.GetFullPath(repositoryPath);

--- a/DMApp.Common/DMAppFileName.cs
+++ b/DMApp.Common/DMAppFileName.cs
@@ -1,7 +1,8 @@
 ﻿namespace Skyline.DataMiner.CICD.DMApp.Common
 {
     using System;
-    using System.IO;
+
+    using FileSystem;
 
     /// <summary>
     /// Represents an app package file name.
@@ -35,7 +36,7 @@
                 throw new ArgumentException("The specified file name must end with '.dmapp'.", nameof(fileName));
             }
 
-            if (Path.GetDirectoryName(fileName) != String.Empty)
+            if (FileSystem.Instance.Path.GetDirectoryName(fileName) != String.Empty)
             {
                 throw new ArgumentException("The specified file name can not have a directory structure.", nameof(fileName));
             }

--- a/DMApp.Dashboard/AppPackageCreatorForDashboard.cs
+++ b/DMApp.Dashboard/AppPackageCreatorForDashboard.cs
@@ -1,7 +1,6 @@
 namespace Skyline.DataMiner.CICD.DMApp.Dashboard
 {
     using System;
-    using System.IO;
     using System.Threading.Tasks;
 
     using Skyline.DataMiner.CICD.DMApp.Common;
@@ -43,7 +42,7 @@ namespace Skyline.DataMiner.CICD.DMApp.Dashboard
                 string targetPath;
                 if (relativePath.Contains("\\"))
                 {
-                    targetPath = Path.Combine(@"C:\Skyline DataMiner\Dashboards", Path.GetDirectoryName(relativePath));
+                    targetPath = FileSystem.Path.Combine(@"C:\Skyline DataMiner\Dashboards", FileSystem.Path.GetDirectoryName(relativePath));
                 }
                 else
                 {

--- a/DMApp.Visio/AppPackageCreatorForProtocolVisio.cs
+++ b/DMApp.Visio/AppPackageCreatorForProtocolVisio.cs
@@ -1,8 +1,6 @@
 ﻿namespace Skyline.DataMiner.CICD.DMApp.Visio
 {
     using System;
-    using System.IO;
-    using System.Linq;
     using System.Threading.Tasks;
 
     using Skyline.AppInstaller;

--- a/DMApp.Visio/AppPackageCreatorForVisio.cs
+++ b/DMApp.Visio/AppPackageCreatorForVisio.cs
@@ -1,7 +1,6 @@
 ﻿namespace Skyline.DataMiner.CICD.DMApp.Visio
 {
     using System;
-    using System.IO;
     using System.Threading.Tasks;
 
     using Skyline.AppInstaller;

--- a/DMProtocol/ProtocolPackageCreator.cs
+++ b/DMProtocol/ProtocolPackageCreator.cs
@@ -112,7 +112,7 @@
                     if (assembly.AssemblyPath != null)
                     {
                         string destinationFilePath = FileSystem.Instance.Path.Combine(destinationDllFolder, assembly.DllImport);
-                        string destinationFolderPath = FileSystem.Instance.Path.GetFullPath(destinationFilePath);
+                        string destinationFolderPath = FileSystem.Instance.Path.GetDirectoryName(destinationFilePath);
                         packageBuilder.WithAssembly(assembly.AssemblyPath, destinationFolderPath);
                     }
                 }
@@ -125,13 +125,13 @@
             /// <param name="packageBuilder">Protocol Package Builder.</param>
             /// <param name="destinationDllFolder">Destination folder on DataMiner.</param>
             /// <param name="repositoryPath">Solution location.</param>
-            private static void AddAssemblies(string dllsFolderPath, IAppPackageProtocolBuilder packageBuilder, string destinationDllFolder, string repositoryPath)
+            private static void AddAssemblies(string dllsFolder, IAppPackageProtocolBuilder packageBuilder, string destinationDllFolder, string repositoryPath)
             {
-                string destinationsDllsFolderPath = FileSystem.Instance.Path.Combine(FileSystem.Instance.Path.GetFullPath(repositoryPath), "Dlls");
+                string dllsFolderPath = FileSystem.Instance.Path.Combine(FileSystem.Instance.Path.GetFullPath(repositoryPath), "Dlls");
 
-                if (FileSystem.Instance.Directory.Exists(destinationsDllsFolderPath))
+                if (FileSystem.Instance.Directory.Exists(dllsFolderPath))
                 {
-                    foreach (var dll in FileSystem.Instance.Directory.EnumerateFiles(dllsFolderPath, "*.dll"))
+                    foreach (var dll in FileSystem.Instance.Directory.EnumerateFiles(dllsFolder, "*.dll"))
                     {
                         packageBuilder.WithAssembly(dll, destinationDllFolder);
                     }

--- a/DMProtocol/ProtocolPackageCreator.cs
+++ b/DMProtocol/ProtocolPackageCreator.cs
@@ -1,7 +1,6 @@
 ﻿namespace Skyline.DataMiner.CICD.DMProtocol
 {
     using System;
-    using System.IO;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -12,6 +11,7 @@
     using Skyline.DataMiner.CICD.Loggers;
     using Skyline.DataMiner.CICD.Models.Protocol.Read;
     using Skyline.DataMiner.CICD.Parsers.Protocol.VisualStudio;
+    using Skyline.DataMiner.CICD.FileSystem;
 
     /// <summary>
     /// Package creator for Protocol solutions.
@@ -30,7 +30,7 @@
             /// <param name="repositoryPath">The path of the repository that contains the Protocol solution.</param>
             /// <returns>The <see cref="IAppPackageProtocol"/> instance.</returns>
             /// <exception cref="ArgumentNullException"><paramref name="logCollector"/>, <paramref name="repositoryPath"/> is <see langword="null"/>.</exception>
-            /// <exception cref="DirectoryNotFoundException">The directory specified in <paramref name="repositoryPath"/> does not exist.</exception>
+            /// <exception cref="System.IO.DirectoryNotFoundException">The directory specified in <paramref name="repositoryPath"/> does not exist.</exception>
             /// <exception cref="AssemblerException">Project with name could not be found.</exception>
             /// <exception cref="InvalidOperationException">The protocol does not have a name specified in the Name tag.
             /// -or-
@@ -57,12 +57,12 @@
             {
                 if (repositoryPath == null) throw new ArgumentNullException(nameof(repositoryPath));
 
-                repositoryPath = Path.GetFullPath(repositoryPath);
+                repositoryPath = FileSystem.Instance.Path.GetFullPath(repositoryPath);
 
                 if (String.IsNullOrWhiteSpace(repositoryPath)) throw new ArgumentException("Invalid repository path", nameof(repositoryPath));
-                if (!Directory.Exists(repositoryPath)) throw new DirectoryNotFoundException($"Directory '{repositoryPath}' not found.");
+                if (!FileSystem.Instance.Directory.Exists(repositoryPath)) throw new System.IO.DirectoryNotFoundException($"Directory '{repositoryPath}' not found.");
 
-                string solutionFilePath = Directory.GetFiles(repositoryPath, "*.sln", SearchOption.TopDirectoryOnly).FirstOrDefault();
+                string solutionFilePath = FileSystem.Instance.Directory.GetFiles(repositoryPath, "*.sln", System.IO.SearchOption.TopDirectoryOnly).FirstOrDefault();
 
                 if (solutionFilePath == null) throw new InvalidOperationException("The specified repository path does not contain a solution (.sln) file in the root folder.");
 
@@ -96,7 +96,7 @@
 
                 AddNuGetAssemblies(buildResultItems, destinationDllFolder, packageBuilder);
 
-                DirectoryInfo dllsFolder = new DirectoryInfo(Path.Combine(repositoryPath, "Dlls"));
+                string dllsFolder = FileSystem.Instance.Path.Combine(repositoryPath, "Dlls");
                 AddAssemblies(dllsFolder, packageBuilder, destinationDllFolder, repositoryPath);
 
                 IAppPackageProtocol protocolPackage = packageBuilder.Build();
@@ -111,8 +111,8 @@
                     // Can be null in cases where a DataMiner DLL must be included in the dllImport attribute but must not be included in the Dlls folder.
                     if (assembly.AssemblyPath != null)
                     {
-                        string destinationFilePath = Path.Combine(destinationDllFolder, assembly.DllImport);
-                        string destinationFolderPath = new FileInfo(destinationFilePath).Directory.FullName;
+                        string destinationFilePath = FileSystem.Instance.Path.Combine(destinationDllFolder, assembly.DllImport);
+                        string destinationFolderPath = FileSystem.Instance.Path.GetFullPath(destinationFilePath);
                         packageBuilder.WithAssembly(assembly.AssemblyPath, destinationFolderPath);
                     }
                 }
@@ -125,15 +125,15 @@
             /// <param name="packageBuilder">Protocol Package Builder.</param>
             /// <param name="destinationDllFolder">Destination folder on DataMiner.</param>
             /// <param name="repositoryPath">Solution location.</param>
-            private static void AddAssemblies(DirectoryInfo dllsFolder, IAppPackageProtocolBuilder packageBuilder, string destinationDllFolder, string repositoryPath)
+            private static void AddAssemblies(string dllsFolderPath, IAppPackageProtocolBuilder packageBuilder, string destinationDllFolder, string repositoryPath)
             {
-                string dllsFolderPath = Path.Combine(Path.GetFullPath(repositoryPath), "Dlls");
+                string destinationsDllsFolderPath = FileSystem.Instance.Path.Combine(FileSystem.Instance.Path.GetFullPath(repositoryPath), "Dlls");
 
-                if (Directory.Exists(dllsFolderPath))
+                if (FileSystem.Instance.Directory.Exists(destinationsDllsFolderPath))
                 {
-                    foreach (var dll in dllsFolder.GetFiles("*.dll"))
+                    foreach (var dll in FileSystem.Instance.Directory.EnumerateFiles(dllsFolderPath, "*.dll"))
                     {
-                        packageBuilder.WithAssembly(dll.FullName, destinationDllFolder);
+                        packageBuilder.WithAssembly(dll, destinationDllFolder);
                     }
                 }
             }


### PR DESCRIPTION
This should take care of the Path problems still encountered in the package creation for .dmprotocol when done from a Linux Environment:

Unhandled exception: System.ArgumentException: ProtocolBuilder: The destination folder must start with 'C:\Skyline DataMiner\'. (Parameter 'destinationFolderPath')
   at Skyline.AppInstaller.AppPackageProtocol.AppPackageProtocolBuilder.WithAssembly(String assemblyFilePath, String destinationFolderPath)