### PR TITLE
Include all the .dll files in the Dlls directory

### DIFF
--- a/DMProtocol/ProtocolPackageCreator.cs
+++ b/DMProtocol/ProtocolPackageCreator.cs
@@ -131,7 +131,7 @@
 
                 if (FileSystem.Instance.Directory.Exists(dllsFolderPath))
                 {
-                    foreach (var dll in FileSystem.Instance.Directory.EnumerateFiles(dllsFolder, "*.dll"))
+                    foreach (var dll in FileSystem.Instance.Directory.EnumerateFiles(dllsFolder, "*.dll", System.IO.SearchOption.AllDirectories))
                     {
                         packageBuilder.WithAssembly(dll, destinationDllFolder);
                     }


### PR DESCRIPTION
If you have a lot of dll it's handy to sort them in folders. 
Feel free to reject this if it clashes with something else. I guess it will then count the dlls as nuget packages when installing?