### PR TITLE
Add multi-targeting and lower NuGet versions for .NET Standard

### DIFF
--- a/Assemblers.Automation/Assemblers.Automation.csproj
+++ b/Assemblers.Automation/Assemblers.Automation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Assemblers.Automation</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.Assemblers.Automation</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Assemblers.Common/Assemblers.Common.csproj
+++ b/Assemblers.Common/Assemblers.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Assemblers.Common</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.Assemblers.Common</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -27,10 +27,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageReference Include="NuGet.PackageManagement" Version="6.6.2" />
     <PackageReference Include="Skyline.DataMiner.CICD.Common" Version="1.0.6" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\Parsers.Common\Parsers.Common.csproj" />

--- a/Assemblers.Protocol/Assemblers.Protocol.csproj
+++ b/Assemblers.Protocol/Assemblers.Protocol.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Assemblers.Protocol</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.Assemblers.Protocol</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -35,6 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Skyline.DataMiner.CICD.Models.Protocol" Version="1.2.0" />
+    <PackageReference Include="Skyline.DataMiner.CICD.Models.Protocol" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/DMApp.Automation/DMApp.Automation.csproj
+++ b/DMApp.Automation/DMApp.Automation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.DMApp.Automation</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.DMApp.Automation</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/DMApp.Common/DMApp.Common.csproj
+++ b/DMApp.Common/DMApp.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.DMApp.Common</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.DMApp.Common</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/DMApp.Dashboard/DMApp.Dashboard.csproj
+++ b/DMApp.Dashboard/DMApp.Dashboard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.DMApp.Dashboard</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.DMApp.Dashboard</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/DMApp.SrmFunction/DMApp.SrmFunction.csproj
+++ b/DMApp.SrmFunction/DMApp.SrmFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DMApp.Visio/DMApp.Visio.csproj
+++ b/DMApp.Visio/DMApp.Visio.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.DMApp.Visio</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.DMApp.Visio</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/DMProtocol/DMProtocol.csproj
+++ b/DMProtocol/DMProtocol.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.DMProtocol</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.DMProtocol</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Parsers.Automation/Parsers.Automation.csproj
+++ b/Parsers.Automation/Parsers.Automation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Parsers.Automation</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.Parsers.Automation</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Parsers.Common/Parsers.Common.csproj
+++ b/Parsers.Common/Parsers.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Parsers.Common</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.Parsers.Common</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Parsers.Protocol/Parsers.Protocol.csproj
+++ b/Parsers.Protocol/Parsers.Protocol.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>Skyline.DataMiner.CICD.Parsers.Protocol</AssemblyName>
     <RootNamespace>Skyline.DataMiner.CICD.Parsers.Protocol</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
We need to lower the Microsoft.CodeAnalysis NuGet packages to the previous range as it clashes with other NuGet packages used within DIS. As DIS isn't in .NET, this is only applicable for .NET Standard.