### PR TITLE
Quickfix ignore QAOps TestContent

### DIFF
--- a/Assemblers.Automation/AutomationScriptBuilder.cs
+++ b/Assemblers.Automation/AutomationScriptBuilder.cs
@@ -567,7 +567,7 @@
         private static IList<ProjectFile> GetRelevantCodeFilesSorted(Project project)
         {
             var files = project.Files
-                               .Where(x => x.Name.EndsWith(".cs") && !x.Name.EndsWith("AssemblyInfo.cs"))
+                               .Where(x => x.Name.EndsWith(".cs") && !x.Name.EndsWith("AssemblyInfo.cs") && !x.Name.Contains("TestPackageContent\\TestHarvesting\\") && !x.Name.Contains("TestPackageContent/TestHarvesting/") && !x.Name.Contains("TestPackageContent\\Tests\\") && !x.Name.Contains("TestPackageContent/Tests/"))
                                .OrderByDescending(IsMainCodeFile)
                                .ThenByDescending(x => x.Name.StartsWith("script", StringComparison.OrdinalIgnoreCase))
                                .ThenBy(x => x.Name)

--- a/Assemblers.AutomationTests/AutomationScriptBuilderTests.cs
+++ b/Assemblers.AutomationTests/AutomationScriptBuilderTests.cs
@@ -127,7 +127,7 @@
 
             var projects = new Dictionary<string, Project>()
             {
-                { "Script_1", new Project("Script_1", new[]{ new ProjectFile("Script.cs", "using System;"), new ProjectFile("TestPackageContent\\TestHarvesting\\test.cs", "using System;") }) },
+                { "Script_1", new Project("Script_1", new[]{ new ProjectFile("Script.cs", "using System;"), new ProjectFile("TestPackageContent\\TestHarvesting\\test.cs", "using System.Linq;") }) },
             };
 
             Script script = new Script(XmlDocument.Parse(original));

--- a/Assemblers.AutomationTests/AutomationScriptBuilderTests.cs
+++ b/Assemblers.AutomationTests/AutomationScriptBuilderTests.cs
@@ -105,6 +105,42 @@
             Assert.IsFalse(d.HasDifferences(), d.ToString());
         }
 
+
+        [TestMethod]
+        public async Task SLDisCompiler_AutomationScriptBuilder_IgnoreTestingFilesAsync()
+        {
+            string original = @"<DMSScript>
+	<Script>
+		<Exe id=""1"" type=""csharp"">
+            <Value>[Project:Script_1]</Value>
+        </Exe>
+	</Script>
+</DMSScript>";
+
+            string expected = @"<DMSScript>
+	<Script>
+		<Exe id=""1"" type=""csharp"">
+            <Value><![CDATA[using System;]]></Value>
+        </Exe>
+	</Script>
+</DMSScript>";
+
+            var projects = new Dictionary<string, Project>()
+            {
+                { "Script_1", new Project("Script_1", new[]{ new ProjectFile("Script.cs", "using System;"), new ProjectFile("TestPackageContent\\TestHarvesting\\test.cs", "using System;") }) },
+            };
+
+            Script script = new Script(XmlDocument.Parse(original));
+            AutomationScriptBuilder builder = new AutomationScriptBuilder(script, projects, new List<Script> { script }, directoryForNuGetConfig: null);
+
+            string result = (await builder.BuildAsync().ConfigureAwait(false)).Document;
+
+            Diff d = DiffBuilder.Compare(Input.FromString(expected))
+                .WithTest(Input.FromString(result)).Build();
+
+            Assert.IsFalse(d.HasDifferences(), d.ToString());
+        }
+
         [TestMethod]
         public async Task SLDisCompiler_AutomationScriptBuilder_MultipleScriptsAsync()
         {


### PR DESCRIPTION
This pull request introduces improvements to the code file selection logic in the automation script builder and adds a corresponding unit test to ensure that testing-related files are excluded from processing. The changes enhance the reliability of script generation by preventing unwanted test files from being included.

Enhancement to code file selection:

* Updated `GetRelevantCodeFilesSorted` in `AutomationScriptBuilder.cs` to exclude files located in `TestPackageContent/TestHarvesting` and `TestPackageContent/Tests` directories, ensuring only relevant code files are processed.

Testing improvements:

* Added a new test method `SLDisCompiler_AutomationScriptBuilder_IgnoreTestingFilesAsync` in `AutomationScriptBuilderTests.cs` to verify that files from testing directories are ignored during script building.