### PR TITLE
Only exclude NuGet.Frameworks when needed

### DIFF
--- a/.github/workflows/private-dataminer-cicd-nugetsolution.yml
+++ b/.github/workflows/private-dataminer-cicd-nugetsolution.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   CICD:
-    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@MasterWorkflow
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@main
     with:
       sonarcloud-project-name: SkylineCommunications_Skyline.DataMiner.CICD.Packages
       solution-filter-name: Skyline.DataMiner.CICD.Packages.sln

--- a/Assemblers.AutomationTests/Assemblers.AutomationTests.csproj
+++ b/Assemblers.AutomationTests/Assemblers.AutomationTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" />
     <PackageReference Include="XMLUnit.Core" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Assemblers.CommonTests/Assemblers.CommonTests.csproj
+++ b/Assemblers.CommonTests/Assemblers.CommonTests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="MSTest" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Assemblers.ProtocolTests/Assemblers.ProtocolTests.csproj
+++ b/Assemblers.ProtocolTests/Assemblers.ProtocolTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="MSTest" />
     <PackageReference Include="XMLUnit.Core" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DMApp.AutomationTests/DMApp.AutomationTests.csproj
+++ b/DMApp.AutomationTests/DMApp.AutomationTests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="MSTest" />
     <PackageReference Include="XMLUnit.Core" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DMProtocolTests/DMProtocolTests.csproj
+++ b/DMProtocolTests/DMProtocolTests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="MSTest" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
         <Version>9.0.0</Version>
+        <PackageOutputPath Condition="$(USERPROFILE.Contains('MichielOD'))">C:\Users\MichielOD\OneDrive - Skyline Communications NV\Documents\MyNugets</PackageOutputPath>
     </PropertyGroup>
 
     <!-- Properties for NuGet projects -->
@@ -23,10 +24,6 @@
         <None Include="..\README.md" Pack="true" PackagePath="" />
         <None Include="..\_NuGetItems\icon.png" Pack="true" PackagePath="" />
         <None Include="..\_NuGetItems\LICENSE.txt" Pack="true" PackagePath="" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net48'">

--- a/Tools.Packager/CICD.Tools.Packager.csproj
+++ b/Tools.Packager/CICD.Tools.Packager.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Skyline.DataMiner.CICD.Tools.Reporter" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request mainly updates NuGet package references and workflow configuration across the solution. The most significant changes involve moving the `NuGet.Frameworks` dependency from the global build props to individual test and tool projects, and updating the workflow to use the correct branch. Additionally, a user-specific package output path is added for local development convenience.

**Dependency management:**

* Removed the global `NuGet.Frameworks` package reference from `Directory.Build.props` and added it directly to the following projects with appropriate `ExcludeAssets` and `PrivateAssets` attributes:  
  * `Assemblers.AutomationTests.csproj`  
  * `Assemblers.CommonTests.csproj`  
  * `Assemblers.ProtocolTests.csproj`  
  * `DMApp.AutomationTests.csproj`  
  * `DMProtocolTests.csproj`  
  * `CICD.Tools.Packager.csproj`  
  * Removed from `Directory.Build.props`

**Workflow configuration:**

* Updated the reusable workflow reference in `.github/workflows/private-dataminer-cicd-nugetsolution.yml` to use the `main` branch instead of `MasterWorkflow` for improved consistency and reliability.

**Developer experience:**

* Added a conditional `PackageOutputPath` in `Directory.Build.props` for the user `MichielOD` to support a custom local NuGet package output directory.