### PR TITLE
PackageReferenceProcessor - Take in account other NuGet.Config file from .NET CLI

### DIFF
--- a/Assemblers.Common/PackageReferenceProcessor.cs
+++ b/Assemblers.Common/PackageReferenceProcessor.cs
@@ -104,6 +104,12 @@
             }
 
             LogDebug($"NuGet Root Path: {NuGetRootPath}");
+
+            LogDebug($"Directory with potential NuGet.config file: {directoryForNuGetConfig}");
+            foreach (string configFilePath in settings.GetConfigFilePaths())
+            {
+                LogDebug($"Config File: {configFilePath}");
+            }
         }
 
         /// <summary>
@@ -275,7 +281,7 @@
                             {
                                 nugetPackageAssemblies.ImplicitDllImportDirectoryReferences.Add(dllImportDirectory);
                             }
-                            
+
                             (bool dontAddToPackageToInstall, PackageAssemblyReference packageAssemblyReference) = CreatePackageAssemblyReference(resolvedPackage, filteredLibItem, dllImportDirectory);
 
                             // Needs to be added as a reference in the dllImport attribute/script references.

--- a/Assemblers.Common/PackageReferenceProcessor.cs
+++ b/Assemblers.Common/PackageReferenceProcessor.cs
@@ -57,8 +57,7 @@
             nuGetLogger = NullLogger.Instance;
 
             // Start with the lowest settings. It will automatically look at the other NuGet.config files it can find on the default locations
-            settings = Settings.LoadDefaultSettings(root: directoryForNuGetConfig);
-
+            settings = Settings.LoadDefaultSettings(root: null);
             clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, nuGetLogger);
 
             var provider = new PackageSourceProvider(settings);

--- a/Assemblers.Common/PackageReferenceProcessor.cs
+++ b/Assemblers.Common/PackageReferenceProcessor.cs
@@ -109,6 +109,13 @@
             foreach (string configFilePath in settings.GetConfigFilePaths())
             {
                 LogDebug($"Config File: {configFilePath}");
+                string content = FileSystem.Instance.File.ReadAllText(configFilePath);
+                LogDebug($"Config File Content: {content}");
+            }
+
+            foreach (PackageSource loadPackageSource in sourceRepositoryProvider.PackageSourceProvider.LoadPackageSources())
+            {
+                LogDebug($"[{loadPackageSource.IsEnabled}] {loadPackageSource.Name} - {loadPackageSource.Source}");
             }
         }
 

--- a/Assemblers.Common/PackageReferenceProcessor.cs
+++ b/Assemblers.Common/PackageReferenceProcessor.cs
@@ -78,7 +78,7 @@
             }
 
             clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, nuGetLogger);
-            
+
             var provider = new PackageSourceProvider(settings);
             sourceRepositoryProvider = new SourceRepositoryProvider(provider, Repository.Provider.GetCoreV3());
 

--- a/Assemblers.Common/PackageReferenceProcessor.cs
+++ b/Assemblers.Common/PackageReferenceProcessor.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -57,9 +58,27 @@
             nuGetLogger = NullLogger.Instance;
 
             // Start with the lowest settings. It will automatically look at the other NuGet.config files it can find on the default locations
-            settings = Settings.LoadDefaultSettings(root: null);
-            clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, nuGetLogger);
+            settings = Settings.LoadDefaultSettings(root: directoryForNuGetConfig);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Get current config paths
+                var configPaths = settings.GetConfigFilePaths().ToList();
 
+                // On Linux/Mac, .NET CLI writes to ~/.nuget/NuGet/NuGet.Config
+                // which differs from the SDK default ~/.config/NuGet/NuGet.Config.
+                string dotnetCliConfigPath = _fileSystem.Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".nuget", "NuGet", "NuGet.Config");
+
+                if (_fileSystem.File.Exists(dotnetCliConfigPath) && !configPaths.Contains(dotnetCliConfigPath))
+                {
+                    configPaths.Add(dotnetCliConfigPath);
+                    settings = Settings.LoadSettingsGivenConfigPaths(configPaths);
+                }
+            }
+
+            clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, nuGetLogger);
+            
             var provider = new PackageSourceProvider(settings);
             sourceRepositoryProvider = new SourceRepositoryProvider(provider, Repository.Provider.GetCoreV3());
 
@@ -108,8 +127,6 @@
             foreach (string configFilePath in settings.GetConfigFilePaths())
             {
                 LogDebug($"Config File: {configFilePath}");
-                string content = FileSystem.Instance.File.ReadAllText(configFilePath);
-                LogDebug($"Config File Content: {content}");
             }
 
             foreach (PackageSource loadPackageSource in sourceRepositoryProvider.PackageSourceProvider.LoadPackageSources())

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSourceMapping>
-    <packageSource key="nuget.org">
-        <package pattern="*" />
-      </packageSource>
-  </packageSourceMapping>
+    <packageSourceMapping>
+        <packageSource key="nuget.org">
+            <package pattern="*" />
+            <package pattern="Skyline.DataMiner.CICD.*" />
+        </packageSource>
+
+        <!-- Reusable Workflow -->
+        <packageSource key="PrivateGitHubNuGets">
+            <package pattern="Skyline.DataMiner.CICD.*" />
+        </packageSource>
+
+        <!-- MichielOD -->
+        <packageSource key="GitHub">
+            <package pattern="Skyline.DataMiner.CICD.*" />
+        </packageSource>
+    </packageSourceMapping>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,7 @@
         </packageSource>
 
         <!-- Reusable Workflow -->
-        <packageSource key="PrivateGitHubNuGets">
+        <packageSource key="PrivateGitHubNugets">
             <package pattern="Skyline.DataMiner.CICD.*" />
         </packageSource>
 


### PR DESCRIPTION
This pull request improves cross-platform compatibility for NuGet configuration handling and enhances logging for debugging, as well as updates the `NuGet.config` to better support package source mapping for specific package patterns.

**Cross-platform NuGet config handling:**

* Updated `PackageReferenceProcessor` to explicitly include the `.NET CLI`-specific NuGet config path (`~/.nuget/NuGet/NuGet.Config`) on non-Windows systems if present, ensuring all relevant config files are loaded for consistent behavior across operating systems. [[1]](diffhunk://#diff-893796e6e783a983829c27503eda341c45012a4deccc4f4842e37dcbc6f7e71cR6) [[2]](diffhunk://#diff-893796e6e783a983829c27503eda341c45012a4deccc4f4842e37dcbc6f7e71cR62-R78)

**Logging improvements:**

* Added debug logging to output the detected NuGet root path, the directory for possible NuGet config files, all config file paths being used, and the loaded package sources with their enabled status, improving traceability and troubleshooting.

**NuGet package source mapping updates:**

* Enhanced `NuGet.config` to:
  - Add the pattern `Skyline.DataMiner.CICD.*` to the `nuget.org` source.
  - Define new package sources (`PrivateGitHubNuGets` and `GitHub`) with mappings for `Skyline.DataMiner.CICD.*` packages, supporting better package resolution and source separation.

These changes ensure more reliable package resolution in multi-platform environments and provide better diagnostics for package source configuration issues.